### PR TITLE
feat: ipmi fan service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # manual-fan.service
-An IPMI systemd service too and some useful commands.
+
+## Description
+
+An IPMI systemd service too and some useful commands. This service with use IPMI commands to ensure manual control of fans is enabled. It will also turn off the forced PCIe filled fan to high feature. A Dell PowerEdge r730xd does not seem to offer any fan normal fan control outside or Windows Server OS.
+
+## Installation
+
+To install and use:
+
+1. Add `manual-fan.service` to `/etc/systemd/system/`
+2. `systemctl daemon reload`
+3. `systemctl enable manual-fan.service`
+4. `systemctl start manual-fan.service`
+
+The goal is to use this service in conjunction with another service to control the system fans.
+
+## Useful Notes
+
+Install ipmi: `sudo apt install ipmitool`
+List fans: `sudo ipmitool list | grep Fan`
+Sets all the system fans to lower %: `sudo /us/bin/imitool raw 0x30 0x30 ox02 Oxff Oxb`

--- a/manual-fan.service
+++ b/manual-fan.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=IPMI to enable manual control of fans, enable PICe exclusion
+After=network.target
+StartLimitInvervalSec=120
+StartLimitBurst=5
+
+[Servicel
+Type=oneshot
+ExecStart=/us/bin/ipmitool raw 0x30 0xce 0x00 0x16 0x05 0x00 0x00 0x00 0X05 0x00 0x01 0x00 0x00
+ExecStart=/usr/bin/ipmitool raw 0x30 0×30 0x01 0x00
+ExecStop=/usr/bin/ipmitool raw 0x30 0x30 0x01 0x01
+Restart=on-failure
+RestartSec=5s
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This pull request introduces a new systemd service, `manual-fan.service`, to enable manual control of system fans using IPMI commands. It also updates the `README.md` file with detailed instructions for installation, usage, and additional notes. 

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R22): Expanded with a detailed description of the `manual-fan.service`, installation steps, and useful IPMI commands for managing system fans.

### New Feature:
* [`manual-fan.service`](diffhunk://#diff-84f757a515813f8b90d08b46eee34c8928642fc9b5f65f7ed99827de54d3549eR1-R17): Added a new systemd service configuration file to enable manual fan control and PCIe exclusion using IPMI commands. Includes start, stop, and restart behavior definitions.